### PR TITLE
Minor bug in shannon entropy computing

### DIFF
--- a/src/dynsight/_internal/analysis/shannon_entropy.py
+++ b/src/dynsight/_internal/analysis/shannon_entropy.py
@@ -64,10 +64,10 @@ def compute_entropy_gain(
         a float which is the difference between the entropy of the raw and
         clustered data, relative to the entropy of the raw data.
     """
-    if data.shape != labels.shape:
+    if data.shape[0] != labels.shape[0]:
         msg = (
             f"data ({data.shape}) and labels ({labels.shape}) "
-            "must have same shape"
+            "must have same shape[0]"
         )
         raise RuntimeError(msg)
 

--- a/tests/analysis/test_shannon.py
+++ b/tests/analysis/test_shannon.py
@@ -29,7 +29,7 @@ def test_output_files(original_wd: Path) -> None:  # noqa: ARG001
 
     data_shape = (100, 100)
     random_data = rng.random(data_shape)
-    random_labels = rng.integers(0, 5, data_shape)
+    random_labels = rng.integers(0, 5, (100,))
     wrong_labels = rng.integers(0, 5, (200, 50))
 
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Requested Reviewers: @andrewtarzia

<!--
Sorry Andrew for the never-ending PRs. Chiara started to use the "shannon entropy" stuff and found a bug, which I fixed. 
-->

<!--
More in detail, the function "compute_entropy_gain()" takes as arguments the np.ndarrays "data" and "labels". They don't have the same shape, but this is not a problem, because python is very smart. But in the old version, there was a check that raised an Error if the shapes are not the same. Which never happens, so the function does not work. Now I simply removed the check, and everything works fine. 
-->