### PR TITLE
Implementing time correlation functions

### DIFF
--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -12,3 +12,5 @@ Functions
   compute_data_entropy <_autosummary/dynsight.analysis.compute_data_entropy>
   compute_entropy_gain <_autosummary/dynsight.analysis.compute_entropy_gain>
   compute_rdf <_autosummary/dynsight.analysis.compute_rdf>
+  self_time_correlation <_autosummary/dynsight.analysis.self_time_correlation>
+  cross_time_correlation <_autosummary/dynsight.analysis.cross_time_correlation>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ maintainers = [
 ]
 
 dependencies = [
+  "numpy < 2",
   "cpctools",
   "dscribe >1.2.0, <=1.2.2",
   "tropea-clustering",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 
 dependencies = [
-  "numpy < 2",
+  "numpy < 2", # Needed right now, to remove in the future
   "cpctools",
   "dscribe >1.2.0, <=1.2.2",
   "tropea-clustering",

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -76,11 +76,12 @@ def self_time_correlation(
             for tmp in data
         ]
         correlation[t_prime] = np.mean(corr_sum) / valid_t
-        correlation_error[t_prime] = np.std(corr_sum) / valid_t
+        correlation_error[t_prime] = np.std(corr_sum) / (valid_t * n_part)
 
     # Normalize the correlation function
-    correlation /= correlation[0]
-    correlation_error /= correlation[0]
+    norm_fact = correlation[0]
+    correlation /= norm_fact
+    correlation_error /= norm_fact
 
     return correlation, correlation_error
 

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -77,7 +77,8 @@ def self_time_correlation(
         ]
         correlation[t_prime] = np.mean(corr_sum) / valid_t
         correlation_error[t_prime] = np.std(corr_sum) / (
-            valid_t * np.sqrt(n_part))
+            valid_t * np.sqrt(n_part)
+        )
 
     # Normalize the correlation function
     norm_fact = correlation[0]

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def self_time_correlation(
+    data: np.ndarray[float, Any],
+    max_delay: int | None = None,
+) -> np.ndarray[float, Any]:
+    """Computes the mean self time correlation function for time-series.
+
+    Takes as input an array of shape (n_particles, n_frames), where the
+    element [i][t] is the value of some quantity for particle i at time t.
+    For each particle, computes the self time correlation function (self-TCF).
+    Returns the self-TCF averaged over all the particles, normalized so that
+    the value at t = 0 is equal to 1.
+
+    * Author: Matteo Becchi
+
+    Parameters:
+        data:
+            Array of shape (n_particles, n_frames).
+
+        max_delay:
+            The TCF will be computed for all the delay values from zero to
+            max_delay - 1. If None, il will be set to the maximum possible
+            delay. Default is None.
+
+    Returns:
+        np.ndarray of shape (max_delay,):
+            The values of the TCF for all delays from zero to max_delay - 1.
+
+    Example:
+
+        .. testcode:: tcf-test
+
+            import numpy as np
+            from dynsight.analysis import self_time_correlation
+
+            # Create random input
+            np.random.seed(1234)
+            n_particles = 100
+            n_frames = 100
+            data = np.random.rand(n_particles, n_frames)
+
+            time_corr = self_time_correlation(data)
+
+        .. testcode:: tcf-test
+            :hide:
+
+            assert time_corr[0] == 1.0
+
+    """
+    n_part, n_frames = data.shape
+    # Subtract the mean for each particle
+    data = data - np.mean(data, axis=1, keepdims=True)
+
+    if max_delay is None:
+        max_delay = n_frames
+
+    correlation = np.zeros(max_delay)
+    for t_prime in range(max_delay):
+        # Compute correlation for time lag t_prime
+        valid_t = n_frames - t_prime
+        corr_sum = 0
+        for n in range(n_part):
+            corr_sum += np.dot(
+                data[n, :valid_t],
+                data[n, t_prime : valid_t + t_prime],
+            )
+        correlation[t_prime] = corr_sum / (n_part * valid_t)
+
+    # Normalize the correlation function
+    correlation /= correlation[0]
+    return correlation
+
+
+def cross_time_correlation(
+    data: np.ndarray[float, Any],
+    max_delay: int | None = None,
+) -> np.ndarray[float, Any]:
+    """Computes the mean cross time correlation function for time-series.
+
+    Takes as input an array of shape (n_particles, n_frames), where the
+    element [i][t] is the value of some quantity for particle i at time t.
+    For each particles pair, computes the cross time correlation function
+    (cross-TCF). Returns the cross-TCF averaged over all the particles pairs.
+
+    * Author: Matteo Becchi
+
+    Parameters:
+        data:
+            Array of shape (n_particles, n_frames).
+
+        max_delay:
+            The TCF will be computed for all the delay values from zero to
+            max_delay - 1. If None, il will be set to the maximum possible
+            delay. Default is None.
+
+    Returns:
+        np.ndarray of shape (max_delay,):
+            The values of the TCF for all delays from zero to max_delay - 1.
+
+    Example:
+
+        .. testcode:: tcf-test
+
+            import numpy as np
+            from dynsight.analysis import cross_time_correlation
+
+            # Create random input
+            np.random.seed(1234)
+            n_particles = 100
+            n_frames = 100
+            data = np.random.rand(n_particles, n_frames)
+
+            time_corr = cross_time_correlation(data)
+
+        .. testcode:: tcf-test
+            :hide:
+
+            assert time_corr[0] > 0.0
+
+    """
+    n_part, n_frames = data.shape
+
+    # Subtract the mean for each particle
+    data = data - np.mean(data, axis=1, keepdims=True)
+
+    if max_delay is None:
+        max_delay = n_frames
+
+    # Initialize the cross-correlation array
+    cross_correlation = np.zeros(max_delay)
+
+    # Loop over all time lags t'
+    for t_prime in range(max_delay):
+        valid_t = n_frames - t_prime
+        corr_sum = 0
+
+        # Compute cross-correlation for each pair of particles (i, j)
+        for i in range(n_part):
+            for j in range(n_part):
+                if i != j:  # Skip self-correlation
+                    corr_sum += np.dot(
+                        data[i, :valid_t],
+                        data[j, t_prime : valid_t + t_prime],
+                    )
+
+        # Average over particle pairs (i, j)
+        cross_correlation[t_prime] = corr_sum / (
+            n_part * (n_part - 1) * valid_t
+        )
+
+    return cross_correlation

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -1,5 +1,7 @@
 """Functions for computing correlation functions between particles."""
 
+from __future__ import annotations
+
 from typing import Any
 
 import numpy as np

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -1,4 +1,4 @@
-from __future__ import annotations
+"""Functions for computing correlation functions between particles."""
 
 from typing import Any
 
@@ -25,8 +25,8 @@ def self_time_correlation(
 
         max_delay:
             The TCF will be computed for all the delay values from zero to
-            max_delay - 1. If None, il will be set to the maximum possible
-            delay. Default is None.
+            max_delay - 1 frames. If None, il will be set to the maximum
+            possible delay. Default is None.
 
     Returns:
         tuple[np.ndarray, np.ndarray]:
@@ -108,8 +108,8 @@ def cross_time_correlation(
 
         max_delay:
             The TCF will be computed for all the delay values from zero to
-            max_delay - 1. If None, il will be set to the maximum possible
-            delay. Default is None.
+            max_delay - 1 frames. If None, il will be set to the maximum
+            possible delay. Default is None.
 
     Returns:
         tuple[np.ndarray, np.ndarray]:

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -76,7 +76,8 @@ def self_time_correlation(
             for tmp in data
         ]
         correlation[t_prime] = np.mean(corr_sum) / valid_t
-        correlation_error[t_prime] = np.std(corr_sum) / (valid_t * n_part)
+        correlation_error[t_prime] = np.std(corr_sum) / (
+            valid_t * np.sqrt(n_part))
 
     # Normalize the correlation function
     norm_fact = correlation[0]

--- a/src/dynsight/_internal/analysis/time_correlations.py
+++ b/src/dynsight/_internal/analysis/time_correlations.py
@@ -50,7 +50,7 @@ def self_time_correlation(
         .. testcode:: tcf-test
             :hide:
 
-            assert time_corr[0] == 1.0
+            assert time_corr[1] == 0.005519088806189558
 
     """
     n_part, n_frames = data.shape
@@ -121,7 +121,7 @@ def cross_time_correlation(
         .. testcode:: tcf-test
             :hide:
 
-            assert time_corr[0] > 0.0
+            assert time_corr[0] == 0.0002474572311281276
 
     """
     n_part, n_frames = data.shape

--- a/src/dynsight/analysis.py
+++ b/src/dynsight/analysis.py
@@ -5,5 +5,15 @@ from dynsight._internal.analysis.shannon_entropy import (
     compute_data_entropy,
     compute_entropy_gain,
 )
+from dynsight._internal.analysis.time_correlations import (
+    cross_time_correlation,
+    self_time_correlation,
+)
 
-__all__ = ["compute_data_entropy", "compute_entropy_gain", "compute_rdf"]
+__all__ = [
+    "compute_data_entropy",
+    "compute_entropy_gain",
+    "compute_rdf",
+    "cross_time_correlation",
+    "self_time_correlation",
+]


### PR DESCRIPTION
Requested Reviewers: @andrewtarzia

I thought it makes sense to implement this in dynsight because, although there are quick ways to compute the time correlation function for a signal using some numpy functions, this adds some useful features: 

* you give as input the signals for all the particles of a system, and the function "self_time_correlation" automatically returns the mean over all the particles; 
* the function "cross_time_correlation", instead, computes the cross correlations between the signals of different particles. 

Basically, we are adding the layer of "many body systems" over the time correlation function. 