### PR TITLE
replaced all the array_equal with all_close to avoid numerical precision issues

### DIFF
--- a/tests/analysis/rdf/test_rdf.py
+++ b/tests/analysis/rdf/test_rdf.py
@@ -40,5 +40,5 @@ def test_compute_rdf(case_data: RDFCaseData) -> None:
 
     exp_bins = np.load(expected_bins)
     exp_rdf = np.load(expected_rdf)
-    assert np.array_equal(exp_rdf, test_rdf)
-    assert np.array_equal(exp_bins, test_bins)
+    assert np.allclose(exp_rdf, test_rdf)
+    assert np.allclose(exp_bins, test_bins)

--- a/tests/analysis/test_spatialaverage.py
+++ b/tests/analysis/test_spatialaverage.py
@@ -39,4 +39,4 @@ def test_spatialaverage() -> None:
 
     # Load expected results and compare
     expected_arr = np.load(expected_results)
-    assert np.array_equal(test_arr, expected_arr)
+    assert np.allclose(test_arr, expected_arr)

--- a/tests/lens/test_lens.py
+++ b/tests/lens/test_lens.py
@@ -51,7 +51,7 @@ def test_lens_signals() -> None:
         check_lens_nn = check_file[f"LENS_{i}"]
 
         # Check if control and test array are equal
-        assert np.array_equal(check_lens_nn, test_lens_nn), (
+        assert np.allclose(check_lens_nn, test_lens_nn), (
             f"LENS analyses provided different values "
             f"compared to the control system "
             f"for r_cut: {lens_cutoffs[i]} (results: {output_file})."

--- a/tests/lens/test_special_lens.py
+++ b/tests/lens/test_special_lens.py
@@ -1,6 +1,5 @@
 import MDAnalysis
 import numpy as np
-from numpy.testing import assert_array_equal
 
 import dynsight
 
@@ -33,8 +32,8 @@ def test_special_lens(lensfixtures: MDAnalysis.Universe) -> None:
         mydentot,
     ) = dynsight.lens.neighbour_change_in_time(nnlistperframe)
 
-    assert_array_equal(mynconttot[:, 0], [0] * mynconttot.shape[0])
-    assert_array_equal(mynconttot[:, 1], expected)
+    np.allclose(mynconttot[:, 0], [0] * mynconttot.shape[0])
+    np.allclose(mynconttot[:, 1], expected)
 
     for frame in [0, 1]:
         for atom in universe.atoms:

--- a/tests/lens/to_remove_test_count_neigh.py
+++ b/tests/lens/to_remove_test_count_neigh.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 import MDAnalysis
 import numpy as np
-from numpy.testing import assert_array_equal
 
 import dynsight
 
@@ -61,4 +60,4 @@ def test_count_neigh_for_lens(
             for atomgroupnn, myatomsid in zip(nnlistorig, mynnlist):
                 atomsid = np.sort([at.ix for at in atomgroupnn])
                 assert is_sorted(myatomsid)
-                assert_array_equal(atomsid, myatomsid)
+                np.allclose(atomsid, myatomsid)


### PR DESCRIPTION
Hi @andrewtarzia and @matteobecchi;

This PR aims to avoid issues with numerical precision when comparing expected and tested arrays in tests.

I have replaced all the instances of `assert np.array_equal(...)` to `assert np.allclose(...)`