### PR TITLE
tICA on many-body time-series

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: mypy .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,7 +19,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
-      - run: conda install -c conda-forge deeptime -y
       - run: ruff check .
   mypy:
     runs-on: ubuntu-22.04
@@ -34,7 +33,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
-      - run: conda install -c conda-forge deeptime -y
       - run: mypy .
   ruff-format:
     runs-on: ubuntu-22.04
@@ -49,7 +47,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
-      - run: conda install -c conda-forge deeptime -y
       - run: ruff format --check .
   pytest:
     runs-on: ubuntu-22.04
@@ -64,7 +61,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
-      - run: conda install -c conda-forge deeptime -y
       - run: pytest --cov=src --cov-report term-missing
   doctest:
     runs-on: ubuntu-22.04
@@ -79,5 +75,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
-      - run: conda install -c conda-forge deeptime -y
       - run: make -C docs doctest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,7 +18,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
-      - run: conda install -c conda-forge deeptime
       - run: pip install -e '.[dev]'
       - run: ruff check .
   mypy:
@@ -31,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: mypy .
@@ -45,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: ruff format --check .
@@ -59,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: pytest --cov=src --cov-report term-missing
@@ -73,7 +72,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: make -C docs doctest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
       - run: mypy .

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,6 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
+      - run: conda install -c conda-forge deeptime -y
       - run: ruff check .
   mypy:
     runs-on: ubuntu-22.04
@@ -33,6 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
+      - run: conda install -c conda-forge deeptime -y
       - run: mypy .
   ruff-format:
     runs-on: ubuntu-22.04
@@ -47,6 +49,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
+      - run: conda install -c conda-forge deeptime -y
       - run: ruff format --check .
   pytest:
     runs-on: ubuntu-22.04
@@ -61,6 +64,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
+      - run: conda install -c conda-forge deeptime -y
       - run: pytest --cov=src --cov-report term-missing
   doctest:
     runs-on: ubuntu-22.04
@@ -75,4 +79,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
       - run: pip install -e '.[dev]'
+      - run: conda install -c conda-forge deeptime -y
       - run: make -C docs doctest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,6 +18,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+      - run: conda install -c conda-forge deeptime
       - run: pip install -e '.[dev]'
       - run: ruff check .
   mypy:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,14 @@ Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if you 
 
   $ pip install cpctools
 
+If you want to use the :mod:`dynsight.tica` module you will need to install the deeptime package. This can be done with with pip::
+
+  $ pip install deeptime
+
+or with conda::
+
+  $ conda install -c conda-forge deeptime
+
 Developer Setup
 ...............
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@
    SOAP <soap>
    timeSOAP <time_soap>
    LENS <lens>
+   tICA <tica>
    onion clustering <onion>
    analysis <analysis>
    data processing <data_processing>

--- a/docs/source/tica.rst
+++ b/docs/source/tica.rst
@@ -1,6 +1,15 @@
 tICA
 ====
 
+This module uses the TICA class from the deeptime.decomposition package (see the `documentation page <https://deeptime-ml.github.io/latest/notebooks/tica.html>`_). You will need to install :mod:`deeptime`. This can be done with with pip::
+
+  $ pip install deeptime
+
+or with conda::
+
+  $ conda install -c conda-forge deeptime
+
+
 tICA (time-lagged Independent Component Analysis) is a dimensionality reduction method. Time-series data are mapped to components characterizing the slowest processes, by maximizing the data correlation function at a given lag-time. 
 
 This module allows to perform tICA on trajectories from many-body systems, where the observables under analysis are single-particle descriptors, which should not be mixed within the tICs. 
@@ -12,8 +21,3 @@ Functions
   :maxdepth: 1
 
   many_body_tica <_autosummary/dynsight.tica.many_body_tica>
-
-Acknowledgements
-----------------
-
-This module uses the TICA class from the deeptime.decomposition package (see the `documentation page <https://deeptime-ml.github.io/latest/notebooks/tica.html>`_).

--- a/docs/source/tica.rst
+++ b/docs/source/tica.rst
@@ -1,6 +1,13 @@
 tICA
 ====
 
+tICA (time-lagged Independent Component Analysis) is a dimensionality reduction method. Time-series data are mapped to components characterizing the slowest processes, by maximizing the data correlation function at a given lag-time. 
+
+This module allows to perform tICA on trajectories from many-body systems, where the observables under analysis are single-particle descriptors, which should not be mixed within the tICs. 
+
+Installation
+------------
+
 This module uses the TICA class from the deeptime.decomposition package (see the `documentation page <https://deeptime-ml.github.io/latest/notebooks/tica.html>`_). You will need to install :mod:`deeptime`. This can be done with with pip::
 
   $ pip install deeptime
@@ -9,10 +16,7 @@ or with conda::
 
   $ conda install -c conda-forge deeptime
 
-
-tICA (time-lagged Independent Component Analysis) is a dimensionality reduction method. Time-series data are mapped to components characterizing the slowest processes, by maximizing the data correlation function at a given lag-time. 
-
-This module allows to perform tICA on trajectories from many-body systems, where the observables under analysis are single-particle descriptors, which should not be mixed within the tICs. 
+:mod:`deeptime` requires numpy <= 2.1. 
 
 Functions
 ---------

--- a/docs/source/tica.rst
+++ b/docs/source/tica.rst
@@ -1,0 +1,19 @@
+tICA
+====
+
+tICA (time-lagged Independent Component Analysis) is a dimensionality reduction method. Time-series data are mapped to components characterizing the slowest processes, by maximizing the data correlation function at a given lag-time. 
+
+This module allows to perform tICA on trajectories from many-body systems, where the observables under analysis are single-particle descriptors, which should not be mixed within the tICs. 
+
+Functions
+---------
+
+.. toctree::
+  :maxdepth: 1
+
+  many_body_tica <_autosummary/dynsight.tica.many_body_tica>
+
+Acknowledgements
+----------------
+
+This module uses the TICA class from the deeptime.decomposition package (see the `documentation page <https://deeptime-ml.github.io/latest/notebooks/tica.html>`_).

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ docs:
 # Do a dev install.
 dev:
   pip install -e '.[dev]'
+  conda install -c conda-forge deeptime -y
 
 # Run code checks.
 check:

--- a/justfile
+++ b/justfile
@@ -11,7 +11,6 @@ docs:
 # Do a dev install.
 dev:
   pip install -e '.[dev]'
-  conda install -c conda-forge deeptime -y
 
 # Run code checks.
 check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,6 @@ module = [
     'tropea_clustering.*',
     'h5py.*',
     'SOAPify.*',
+    'deeptime.decomposition.*',
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 ]
 
 dependencies = [
-    "numpy<=2.1",
+    "numpy",
     "dscribe",
     "tropea-clustering",
     "MDAnalysis",
@@ -110,6 +110,5 @@ module = [
     'tropea_clustering.*',
     'h5py.*',
     'SOAPify.*',
-    'deeptime.*'
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,10 +11,11 @@ maintainers = [
 ]
 
 dependencies = [
-    "numpy",
+    "numpy<=2.1",
     "dscribe",
     "tropea-clustering",
     "MDAnalysis",
+    "deeptime",
 ]
 # Set by cpctools.
 requires-python = ">=3.8"
@@ -110,5 +111,6 @@ module = [
     'tropea_clustering.*',
     'h5py.*',
     'SOAPify.*',
+    'deeptime.*'
 ]
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "dscribe",
     "tropea-clustering",
     "MDAnalysis",
-    "deeptime",
 ]
 # Set by cpctools.
 requires-python = ">=3.8"

--- a/src/dynsight/__init__.py
+++ b/src/dynsight/__init__.py
@@ -7,6 +7,7 @@ from dynsight import (
     lens,
     onion,
     soap,
+    tica,
     utilities,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "lens",
     "onion",
     "soap",
+    "tica",
     "utilities",
 ]

--- a/src/dynsight/_internal/analysis/spatial_average.py
+++ b/src/dynsight/_internal/analysis/spatial_average.py
@@ -48,14 +48,15 @@ def processframe(
             if len(value) == 0:
                 continue
             sp_array_frame[key, :] = np.mean(array[value, frame, :], axis=0)
-    else:
-        sp_array_frame = np.zeros(array.shape[0])
-        for key, value in sp_dict.items():
-            if len(value) == 0:
-                continue
-            sp_array_frame[key] = np.mean(array[value, frame])
+        return frame, sp_array_frame
 
-    return frame, sp_array_frame
+    sp_array_frame_1 = np.zeros(array.shape[0])
+    for key, value in sp_dict.items():
+        if len(value) == 0:
+            continue
+        sp_array_frame_1[key] = np.mean(array[value, frame])
+
+    return frame, sp_array_frame_1
 
 
 def spatialaverage(

--- a/src/dynsight/_internal/analysis/spatial_average.py
+++ b/src/dynsight/_internal/analysis/spatial_average.py
@@ -168,12 +168,12 @@ def spatialaverage(
     two_dim = 2
     three_dim = 3
     if descriptor_array.ndim == two_dim:
-        sp_array = np.zeros(
+        sp_array_2 = np.zeros(
             (descriptor_array.shape[0], descriptor_array.shape[1])
         )
         is_vector = False
     elif descriptor_array.ndim == three_dim:
-        sp_array = np.zeros(
+        sp_array_3 = np.zeros(
             (
                 descriptor_array.shape[0],
                 descriptor_array.shape[1],
@@ -198,9 +198,12 @@ def spatialaverage(
     results = pool.map(processframe, args)
     pool.close()
     pool.join()
+
+    if is_vector:
+        for frame, sp_array_frame in results:
+            sp_array_3[:, frame, :] = sp_array_frame
+        return sp_array_3
+
     for frame, sp_array_frame in results:
-        if is_vector:
-            sp_array[:, frame, :] = sp_array_frame
-        else:
-            sp_array[:, frame] = sp_array_frame
-    return sp_array
+        sp_array_2[:, frame] = sp_array_frame
+    return sp_array_2

--- a/src/dynsight/_internal/tica/tica.py
+++ b/src/dynsight/_internal/tica/tica.py
@@ -25,7 +25,8 @@ def many_body_tica(
     suggested one if data are subsequently clustered.
 
     This function uses the TICA module from the deeptime package; refer to
-    Moritz Hoffmann et al 2022 Mach. Learn.: Sci. Technol. 3 015009.
+    `Moritz Hoffmann et al 2022 Mach. Learn.: Sci. Technol. 3 015009
+    <https://iopscience.iop.org/article/10.1088/2632-2153/ac3de0/meta>`_.
 
     Parameters:
         data: shape (n_atoms, n_frames, n_dims)

--- a/src/dynsight/_internal/tica/tica.py
+++ b/src/dynsight/_internal/tica/tica.py
@@ -1,0 +1,77 @@
+"""tICA package."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+import numpy as np
+from deeptime.decomposition import TICA
+
+
+def many_body_tica(
+    data: NDArray[np.float64],
+    lag_time: int,
+    tica_dim: int,
+) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]]:
+    """Perform tICA on trajectories from a many-body system.
+
+    The tICA model is fitted on the entire dataset, concatenating different
+    atoms one after the other. Then, with this model, the trajectories of the
+    individual atoms are trnsformed individually.
+
+    This function uses the TICA module from the deeptime package; refer to
+    Moritz Hoffmann et al 2022 Mach. Learn.: Sci. Technol. 3 015009.
+
+    Parameters:
+        data: shape (n_atoms, n_frames, n_dims)
+            The multivariated data for tICA dimensionality reduction.
+
+        lag_time
+            The time at which time correlations are maximized.
+
+        tica_dim
+            The number of tIC to compute.
+
+    Returns:
+        * The typical relaxation time-scale of each tIC
+        * The coefficient matrix for the tICA projection;
+            shape (tica_dim, n_dims)
+        * The original dataset projected onto tICs;
+            shape (n_atoms, n_frames, tica_dim)
+
+    Example:
+
+        .. testcode:: tica1-test
+
+            import numpy as np
+            import dynsight
+
+            np.random.seed(42)
+            random_array = np.random.rand(100, 100, 10)
+
+            relax_times, *_ = dynsight.tica.many_body_tica(
+                random_array, lag_time=10, tica_dim=3)
+
+        .. testcode:: tica1-test
+            :hide:
+
+            assert np.isclose(relax_times[0], 3.104290041516281)
+
+    """
+    *_, n_dim = data.shape
+
+    tica = TICA(lagtime=lag_time, dim=tica_dim)
+    full_dataset = data.reshape(-1, n_dim)
+    tica.fit(full_dataset, scaling="kinetic_map")
+
+    koopman_model = tica.fetch_model()
+    relax_times = koopman_model.timescales()
+
+    eigenvectors = koopman_model.instantaneous_coefficients
+
+    tica_soap = np.array([tica.transform(atom) for atom in data])
+
+    return relax_times, eigenvectors[:tica_dim], tica_soap

--- a/src/dynsight/_internal/tica/tica.py
+++ b/src/dynsight/_internal/tica/tica.py
@@ -33,10 +33,10 @@ def many_body_tica(
             The multivariated data for tICA dimensionality reduction.
 
         lag_time
-            The time at which time correlations are maximized.
+            The lagtime under which time correlations are maximized.
 
         tica_dim
-            The number of tIC to compute.
+            The number of dimensions to keep.
 
     Returns:
         * The typical relaxation time-scale of each tIC

--- a/src/dynsight/_internal/tica/tica.py
+++ b/src/dynsight/_internal/tica/tica.py
@@ -8,7 +8,11 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 import numpy as np
-from deeptime.decomposition import TICA
+
+try:
+    from deeptime.decomposition import TICA
+except ImportError:
+    TICA = None
 
 
 def many_body_tica(
@@ -47,7 +51,7 @@ def many_body_tica(
 
     Example:
 
-        .. testcode:: tica1-test
+        .. code-block:: python
 
             import numpy as np
             import dynsight
@@ -55,16 +59,14 @@ def many_body_tica(
             np.random.seed(42)
             random_array = np.random.rand(100, 100, 10)
 
-            relax_times, *_ = dynsight.tica.many_body_tica(
+            relax_times, coeffs, tica_data = dynsight.tica.many_body_tica(
                 random_array, lag_time=10, tica_dim=3)
-
-        .. testcode:: tica1-test
-            :hide:
-
-            assert np.isclose(relax_times[0], 3.104290041516281)
-
     """
     *_, n_dim = data.shape
+
+    if TICA is None:
+        msg = "Please install deeptime using pip or conda."
+        raise ModuleNotFoundError(msg)
 
     tica = TICA(lagtime=lag_time, dim=tica_dim)
     full_dataset = data.reshape(-1, n_dim)
@@ -75,6 +77,6 @@ def many_body_tica(
 
     eigenvectors = koopman_model.instantaneous_coefficients
 
-    tica_soap = np.array([tica.transform(atom) for atom in data])
+    tica_data = np.array([tica.transform(atom) for atom in data])
 
-    return relax_times, eigenvectors[:tica_dim], tica_soap
+    return relax_times, eigenvectors[:tica_dim], tica_data

--- a/src/dynsight/_internal/tica/tica.py
+++ b/src/dynsight/_internal/tica/tica.py
@@ -21,6 +21,8 @@ def many_body_tica(
     The tICA model is fitted on the entire dataset, concatenating different
     atoms one after the other. Then, with this model, the trajectories of the
     individual atoms are trnsformed individually.
+    The model is fitted using the 'kinetic_map' scaling, which is the
+    suggested one if data are subsequently clustered.
 
     This function uses the TICA module from the deeptime package; refer to
     Moritz Hoffmann et al 2022 Mach. Learn.: Sci. Technol. 3 015009.

--- a/src/dynsight/tica.py
+++ b/src/dynsight/tica.py
@@ -1,0 +1,9 @@
+"""tICA package."""
+
+from dynsight._internal.tica.tica import (
+    many_body_tica,
+)
+
+__all__ = [
+    "many_body_tica",
+]

--- a/tests/analysis/test_sample_entropy.py
+++ b/tests/analysis/test_sample_entropy.py
@@ -28,7 +28,7 @@ def test_output_files(original_wd: Path) -> None:  # noqa: ARG001
     rng = np.random.default_rng(12345)
 
     random_data = rng.random(100)
-    r_fact = 0.5 * np.std(random_data)
+    r_fact = float(0.5 * np.std(random_data))
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)

--- a/tests/lens/to_remove_test_emulate_lens.py
+++ b/tests/lens/to_remove_test_emulate_lens.py
@@ -148,14 +148,14 @@ def test_emulate_lens(
     assert len(mydentot) == len(den_tot)
 
     # lens Value
-    for atomdata, wantedatomdata in zip(mynconttot, ncont_tot):
-        assert_array_almost_equal(atomdata, wantedatomdata)
+    for atomdata1, wantedatomdata1 in zip(mynconttot, ncont_tot):
+        assert_array_almost_equal(atomdata1, wantedatomdata1)
     # NN count
-    for atomdata, wantedatomdata in zip(mynntot, nn_tot):
-        assert_array_almost_equal(atomdata, wantedatomdata)
+    for atomdata2, wantedatomdata2 in zip(mynntot, nn_tot):
+        assert_array_almost_equal(atomdata2, wantedatomdata2)
     # LENS numerator
-    for atomdata, wantedatomdata in zip(mynumtot, num_tot):
-        assert_array_almost_equal(atomdata, wantedatomdata)
+    for atomdata3, wantedatomdata3 in zip(mynumtot, num_tot):
+        assert_array_almost_equal(atomdata3, wantedatomdata3)
     # LENS denominator
-    for atomdata, wantedatomdata in zip(mydentot, den_tot):
-        assert_array_almost_equal(atomdata, wantedatomdata)
+    for atomdata4, wantedatomdata4 in zip(mydentot, den_tot):
+        assert_array_almost_equal(atomdata4, wantedatomdata4)

--- a/tests/utilities/test_utilities.py
+++ b/tests/utilities/test_utilities.py
@@ -8,7 +8,7 @@ from dynsight.utilities import (
 
 
 def test_find_extrema_points() -> None:
-    x_coords = np.linspace(-5, 5, 400)
+    x_coords = np.array([float(x) for x in np.linspace(-5, 5, 400)])
     y_coords = (x_coords + 3) * (x_coords - 2) ** 2 * (x_coords + 1) ** 3
 
     min_points = find_extrema_points(


### PR DESCRIPTION
Requested Reviewers: @andrewtarzia 

The added module contains a function to perform tICA on a dataset of single-particle descriptors. The model is fitted on the entire dataset, and then the time-series for each particle is projected individually onto the tICs. 

I am using deeptime, they are credited in the documentation. 

Imposing numpy<=2.1 doesn't seem to be causing any problem. 