### PR TITLE
useless tmp dir removed from pytests.

### DIFF
--- a/tests/analysis/test_sample_entropy.py
+++ b/tests/analysis/test_sample_entropy.py
@@ -1,10 +1,5 @@
 """Pytest for dynsight.analysis.compute_sample_entropy."""
 
-import os
-import tempfile
-from pathlib import Path
-from typing import Generator
-
 import numpy as np
 import pytest
 
@@ -13,47 +8,34 @@ import dynsight
 THRESHOLD = 1e-6
 
 
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
-
 # Define the actual test
-def test_output_files(original_wd: Path) -> None:  # noqa: ARG001
+def test_output_files() -> None:
     rng = np.random.default_rng(12345)
 
     random_data = rng.random(100)
     r_fact = float(0.5 * np.std(random_data))
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
-
-        # Test the case where time-series are too short
-        with pytest.raises(ValueError, match="Time-series too short"):
-            _ = dynsight.analysis.sample_entropy(
-                random_data,
-                r_factor=r_fact,
-                m_par=105,
-            )
-
-        # Test the case where distance threshold is too small
-        with pytest.raises(RuntimeError, match="No matching sequences found."):
-            _ = dynsight.analysis.sample_entropy(
-                random_data,
-                r_factor=0.0,
-            )
-
-        # Test the use of the function computing entropy
-        data_sample_entropy = dynsight.analysis.sample_entropy(
+    # Test the case where time-series are too short
+    with pytest.raises(ValueError, match="Time-series too short"):
+        _ = dynsight.analysis.sample_entropy(
             random_data,
             r_factor=r_fact,
+            m_par=105,
         )
 
-        expected_entropy = 1.3062516534463542
-        if isinstance(data_sample_entropy, float):
-            assert np.isclose(data_sample_entropy, expected_entropy)
+    # Test the case where distance threshold is too small
+    with pytest.raises(RuntimeError, match="No matching sequences found."):
+        _ = dynsight.analysis.sample_entropy(
+            random_data,
+            r_factor=0.0,
+        )
+
+    # Test the use of the function computing entropy
+    data_sample_entropy = dynsight.analysis.sample_entropy(
+        random_data,
+        r_factor=r_fact,
+    )
+
+    expected_entropy = 1.3062516534463542
+    if isinstance(data_sample_entropy, float):
+        assert np.isclose(data_sample_entropy, expected_entropy)

--- a/tests/analysis/test_shannon.py
+++ b/tests/analysis/test_shannon.py
@@ -1,30 +1,13 @@
 """Pytest for dynsight.analysis.compute_entropy_gain."""
 
-import os
-import tempfile
-from pathlib import Path
-from typing import Generator
-
 import numpy as np
 import pytest
 
 import dynsight
 
-THRESHOLD = 1e-6
-
-
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
 
 # Define the actual test
-def test_output_files(original_wd: Path) -> None:  # noqa: ARG001
+def test_output_files() -> None:
     rng = np.random.default_rng(12345)
 
     data_shape = (100, 100)
@@ -32,44 +15,41 @@ def test_output_files(original_wd: Path) -> None:  # noqa: ARG001
     random_labels = rng.integers(0, 5, (100,))
     wrong_labels = rng.integers(0, 5, (200, 50))
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
+    # Test the use of the function computing entropy
+    # This is necessary because of type checking:
+    data_min = float(np.min(random_data))
+    data_max = float(np.max(random_data))
+    data_entropy = dynsight.analysis.compute_shannon(
+        random_data,
+        data_range=(data_min, data_max),
+        n_bins=20,
+    )
 
-        # Test the use of the function computing entropy
-        # This is necessary because of type checking:
-        data_min = float(np.min(random_data))
-        data_max = float(np.max(random_data))
-        data_entropy = dynsight.analysis.compute_shannon(
+    expected_entropy = 0.9995963122117133004
+
+    if isinstance(data_entropy, float):
+        assert np.isclose(data_entropy, expected_entropy)
+
+    # Test the case of empty dataset
+    with pytest.raises(ValueError, match="data is empty"):
+        _ = dynsight.analysis.compute_shannon(np.array([]), (0.0, 1.0), 20)
+
+    # Test the case where labels have the wrong shape
+    with pytest.raises(RuntimeError):
+        _ = dynsight.analysis.compute_entropy_gain(
             random_data,
-            data_range=(data_min, data_max),
+            wrong_labels,
             n_bins=20,
         )
 
-        expected_entropy = 0.9995963122117133004
+    # Test the case where it works
+    _, clustering_gain, *_ = dynsight.analysis.compute_entropy_gain(
+        random_data,
+        random_labels,
+        n_bins=20,
+    )
 
-        if isinstance(data_entropy, float):
-            assert np.isclose(data_entropy, expected_entropy)
+    expected_gain = 0.0010842808402454819
 
-        # Test the case of empty dataset
-        with pytest.raises(ValueError, match="data is empty"):
-            _ = dynsight.analysis.compute_shannon(np.array([]), (0.0, 1.0), 20)
-
-        # Test the case where labels have the wrong shape
-        with pytest.raises(RuntimeError):
-            _ = dynsight.analysis.compute_entropy_gain(
-                random_data,
-                wrong_labels,
-                n_bins=20,
-            )
-
-        # Test the case where it works
-        _, clustering_gain, *_ = dynsight.analysis.compute_entropy_gain(
-            random_data,
-            random_labels,
-            n_bins=20,
-        )
-
-        expected_gain = 0.0010842808402454819
-
-        if isinstance(clustering_gain, float):
-            assert np.isclose(clustering_gain, expected_gain)
+    if isinstance(clustering_gain, float):
+        assert np.isclose(clustering_gain, expected_gain)

--- a/tests/analysis/test_time_correlations.py
+++ b/tests/analysis/test_time_correlations.py
@@ -1,30 +1,12 @@
 """Pytest for dynsight.analysis.time_correlations."""
 
-import os
-import tempfile
-from pathlib import Path
-from typing import Generator
-
 import numpy as np
-import pytest
 
 import dynsight
 
-THRESHOLD = 1e-6
-
-
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
 
 # Define the actual test
-def test_output_files(original_wd: Path) -> None:
+def test_output_files() -> None:
     rng = np.random.default_rng(12345)
 
     # Generate random walks
@@ -38,23 +20,20 @@ def test_output_files(original_wd: Path) -> None:
             x_pos += displ[0]
             random_walk[i][j] = x_pos
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        os.chdir(temp_dir)
+    # Test the self-correlation function
+    t_corr, std_dev = dynsight.analysis.self_time_correlation(random_walk)
 
-        # Test the self-correlation function
-        t_corr, std_dev = dynsight.analysis.self_time_correlation(random_walk)
+    exp_t_corr = np.load("tests/analysis/tcorr/t_corr.npy")
+    exp_std_dev = np.load("tests/analysis/tcorr/std_dev.npy")
 
-        exp_t_corr = np.load(original_wd / "tests/analysis/tcorr/t_corr.npy")
-        exp_std_dev = np.load(original_wd / "tests/analysis/tcorr/std_dev.npy")
+    assert np.allclose(t_corr, exp_t_corr)
+    assert np.allclose(std_dev, exp_std_dev)
 
-        assert np.allclose(t_corr, exp_t_corr)
-        assert np.allclose(std_dev, exp_std_dev)
+    # Test the cross-correlation function
+    t_corr, std_dev = dynsight.analysis.cross_time_correlation(random_walk)
 
-        # Test the cross-correlation function
-        t_corr, std_dev = dynsight.analysis.cross_time_correlation(random_walk)
+    exp_t_corr = np.load("tests/analysis/tcorr/c_corr.npy")
+    exp_std_dev = np.load("tests/analysis/tcorr/ctd_dev.npy")
 
-        exp_t_corr = np.load(original_wd / "tests/analysis/tcorr/c_corr.npy")
-        exp_std_dev = np.load(original_wd / "tests/analysis/tcorr/ctd_dev.npy")
-
-        assert np.allclose(t_corr, exp_t_corr)
-        assert np.allclose(std_dev, exp_std_dev)
+    assert np.allclose(t_corr, exp_t_corr)
+    assert np.allclose(std_dev, exp_std_dev)

--- a/tests/onion/test_multi.py
+++ b/tests/onion/test_multi.py
@@ -1,47 +1,32 @@
 """Pytest for dynsight.onion.onion_multi."""
 
-import os
-import tempfile
 from pathlib import Path
-from typing import Generator
 
 import numpy as np
-import pytest
 
 from dynsight.trajectory import Insight
 
 
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
-
 # Define the actual test
-def test_output_files(original_wd: Path) -> None:
-    with tempfile.TemporaryDirectory() as _:
-        ## Create the input data ###
-        n_particles = 5
-        n_steps = 1000
-        rng = np.random.default_rng(12345)
-        random_walk = np.zeros((n_particles, n_steps, 2))
-        for i in range(n_particles):
-            for j in range(1, n_steps):
-                d_x, d_y = rng.normal(), rng.normal()
-                random_walk[i][j][0] = random_walk[i][j - 1][0] + d_x
-                random_walk[i][j][1] = random_walk[i][j - 1][1] + d_y
+def test_output_files() -> None:
+    ## Create the input data ###
+    n_particles = 5
+    n_steps = 1000
+    rng = np.random.default_rng(12345)
+    random_walk = np.zeros((n_particles, n_steps, 2))
+    for i in range(n_particles):
+        for j in range(1, n_steps):
+            d_x, d_y = rng.normal(), rng.normal()
+            random_walk[i][j][0] = random_walk[i][j - 1][0] + d_x
+            random_walk[i][j][1] = random_walk[i][j - 1][1] + d_y
 
-        data = Insight(random_walk)
-        clustering = data.get_onion(delta_t=10)
+    data = Insight(random_walk)
+    clustering = data.get_onion(delta_t=10)
 
-        # Define the paths to the expected output files
-        results_dir = original_wd / "tests/onion/"
-        expected_output_path = results_dir / "output_multi/labels.npy"
+    # Define the paths to the expected output files
+    results_dir = Path("tests/onion/")
+    expected_output_path = results_dir / "output_multi/labels.npy"
 
-        # Compare the contents of the expected and actual output
-        expected_output = np.load(expected_output_path)
-        assert np.allclose(expected_output, clustering.labels)
+    # Compare the contents of the expected and actual output
+    expected_output = np.load(expected_output_path)
+    assert np.allclose(expected_output, clustering.labels)

--- a/tests/onion/test_uni.py
+++ b/tests/onion/test_uni.py
@@ -1,50 +1,35 @@
 """Pytest for dynsight.onion.onion_uni."""
 
-import os
-import tempfile
 from pathlib import Path
-from typing import Generator
 
 import numpy as np
-import pytest
 
 from dynsight.trajectory import Insight
 
 
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
-
 # Define the actual test
-def test_output_files(original_wd: Path) -> None:
-    with tempfile.TemporaryDirectory() as _:
-        ### Create the input data ###
-        rng = np.random.default_rng(12345)
-        n_particles = 5
-        n_steps = 1000
-        random_walk = np.zeros((n_particles, n_steps))
-        for i in range(n_particles):
-            tmp = np.zeros(n_steps)
-            for j in range(1, n_steps):
-                d_x = rng.normal()
-                x_new = tmp[j - 1] + d_x
-                tmp[j] = x_new
-            random_walk[i] = tmp
-        data = Insight(random_walk)
+def test_output_files() -> None:
+    ### Create the input data ###
+    rng = np.random.default_rng(12345)
+    n_particles = 5
+    n_steps = 1000
+    random_walk = np.zeros((n_particles, n_steps))
+    for i in range(n_particles):
+        tmp = np.zeros(n_steps)
+        for j in range(1, n_steps):
+            d_x = rng.normal()
+            x_new = tmp[j - 1] + d_x
+            tmp[j] = x_new
+        random_walk[i] = tmp
+    data = Insight(random_walk)
 
-        ### Perform onion clustering
-        clustering = data.get_onion(delta_t=10)
+    ### Perform onion clustering
+    clustering = data.get_onion(delta_t=10)
 
-        ### Define the paths to the expected output ###
-        results_dir = original_wd / "tests/onion/"
-        expected_output_path = results_dir / "output_uni/labels.npy"
+    ### Define the paths to the expected output ###
+    results_dir = Path("tests/onion/")
+    expected_output_path = results_dir / "output_uni/labels.npy"
 
-        ### Compare the contents of the expected and actual output ###
-        expected_output = np.load(expected_output_path)
-        assert np.allclose(expected_output, clustering.labels)
+    ### Compare the contents of the expected and actual output ###
+    expected_output = np.load(expected_output_path)
+    assert np.allclose(expected_output, clustering.labels)

--- a/tests/soap/test_soap.py
+++ b/tests/soap/test_soap.py
@@ -1,8 +1,6 @@
 """Pytest for dynsight.soap.saponify_trajectory."""
 
-import os
 from pathlib import Path
-from typing import Generator
 
 import MDAnalysis
 import numpy as np
@@ -11,16 +9,6 @@ import pytest
 from dynsight.trajectory import Trj
 
 from .case_data import SOAPCaseData
-
-
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
 
 
 def test_soap(case_data: SOAPCaseData) -> None:

--- a/tests/trajectory/test_trj.py
+++ b/tests/trajectory/test_trj.py
@@ -1,48 +1,33 @@
 """Pytest for dynsight.trajectory.Trj.init methods."""
 
-import os
-import tempfile
 from pathlib import Path
-from typing import Generator
 
 import MDAnalysis
-import pytest
 
 from dynsight.trajectory import Trj
 
 
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
-
-
 # Define the actual test
 def test_output_files() -> None:
-    with tempfile.TemporaryDirectory() as _:
-        input_file_xyz = Path("tests/systems/2_particles.xyz")
-        input_file_gro = Path("tests/systems/balls_7_nvt.gro")
-        input_file_xtc = Path("tests/systems/balls_7_nvt.xtc")
-        universe = MDAnalysis.Universe(input_file_xyz, dt=1)
-        n_frames_xyz = 21
-        n_frames_xtc = 201
+    input_file_xyz = Path("tests/systems/2_particles.xyz")
+    input_file_gro = Path("tests/systems/balls_7_nvt.gro")
+    input_file_xtc = Path("tests/systems/balls_7_nvt.xtc")
+    universe = MDAnalysis.Universe(input_file_xyz, dt=1)
+    n_frames_xyz = 21
+    n_frames_xtc = 201
 
-        # Test default init
-        trj_1 = Trj(universe)
-        assert len(trj_1.universe.trajectory) == n_frames_xyz
+    # Test default init
+    trj_1 = Trj(universe)
+    assert len(trj_1.universe.trajectory) == n_frames_xyz
 
-        # Test init_from_universe
-        trj_2 = Trj.init_from_universe(universe)
-        assert len(trj_2.universe.trajectory) == n_frames_xyz
+    # Test init_from_universe
+    trj_2 = Trj.init_from_universe(universe)
+    assert len(trj_2.universe.trajectory) == n_frames_xyz
 
-        # Test init_from_xyz
-        trj_3 = Trj.init_from_xyz(input_file_xyz, dt=1)
-        assert len(trj_3.universe.trajectory) == n_frames_xyz
+    # Test init_from_xyz
+    trj_3 = Trj.init_from_xyz(input_file_xyz, dt=1)
+    assert len(trj_3.universe.trajectory) == n_frames_xyz
 
-        # Test init_from_xtc
-        trj_4 = Trj.init_from_xtc(input_file_xtc, input_file_gro)
-        assert len(trj_4.universe.trajectory) == n_frames_xtc
+    # Test init_from_xtc
+    trj_4 = Trj.init_from_xtc(input_file_xtc, input_file_gro)
+    assert len(trj_4.universe.trajectory) == n_frames_xtc

--- a/tests/tsoap/test_tsoap.py
+++ b/tests/tsoap/test_tsoap.py
@@ -1,8 +1,6 @@
 """Pytest for dynsight.soap.timesoap."""
 
-import os
 from pathlib import Path
-from typing import Generator
 
 import MDAnalysis
 import numpy as np
@@ -11,16 +9,6 @@ import pytest
 from dynsight.trajectory import Trj
 
 from .case_data import TimeSOAPCaseData
-
-
-@pytest.fixture
-def original_wd() -> Generator[Path, None, None]:
-    original_dir = Path.cwd()
-
-    # Ensure the original working directory is restored after the test
-    yield original_dir
-
-    os.chdir(original_dir)
 
 
 def test_tsoap(case_data: TimeSOAPCaseData) -> None:


### PR DESCRIPTION
Related Issues: #82 
Requested Reviewers: @andrewtarzia 

Probably temporary directories will be necessary for testing the onion plot functions, because they save files. But for now, they are not needed anywhere. 