### PR TITLE
Update tooling and clean up dependancies

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -1,23 +1,22 @@
 name: Publish release
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    push:
+        tags:
+            - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
-  publish-release:
-    runs-on: ubuntu-22.04
-    env:
-      VERSION: ${{ github.ref_name }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: python -m build
-      - run:
-          twine upload
-          -u __token__
-          -p ${{ secrets.PYPI_API_TOKEN }}
-          dist/*
+    publish-release:
+        runs-on: ubuntu-latest
+        env:
+            VERSION: ${{ github.ref_name }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: "3.10"
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: python -m build
+            - run: twine upload
+                  -u __token__
+                  -p ${{ secrets.PYPI_API_TOKEN }}
+                  dist/*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,78 +1,78 @@
 name: Tests
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    pull_request:
+    workflow_dispatch:
 jobs:
-  ruff:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.13' ]
-    name: ruff on ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: ruff check .
-  mypy:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.13' ]
-    name: mypy on ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: mypy .
-  ruff-format:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.13' ]
-    name: ruff-format on ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: ruff format --check .
-  pytest:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.13' ]
-    name: pytest on ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: pytest --cov=src --cov-report term-missing
-  doctest:
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.13' ]
-    name: doctest on ${{ matrix.python-version }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - run: pip install -e '.[dev]'
-      - run: make -C docs doctest
+    ruff:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.13"]
+        name: ruff on ${{ matrix.python-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: ruff check .
+    mypy:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.13"]
+        name: mypy on ${{ matrix.python-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: mypy .
+    ruff-format:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.13"]
+        name: ruff-format on ${{ matrix.python-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: ruff format --check .
+    pytest:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.13"]
+        name: pytest on ${{ matrix.python-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: pytest --cov=src --cov-report term-missing
+    doctest:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                python-version: ["3.10", "3.13"]
+        name: doctest on ${{ matrix.python-version }}
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: "pip"
+            - run: pip install -e '.[dev]'
+            - run: make -C docs doctest

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ examples/analysis_workflow/water_lens.json
 examples/info_gain/trj_*.npy
 tests/systems/coex/.*
 tests/systems/.*
+
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ you are using Python 3.10 and below, you can use :mod:`cpctools` to access
   $ pip install cpctools
 
 If you want to use the :mod:`dynsight.tica` module you will need to install the
- deeptime package. This can be done with with pip::
+deeptime package. This can be done with with pip::
 
   $ pip install deeptime
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ To get ``dynsight``, you can install it with pip::
 How to contribute
 =================
 
-If you make changes or improvements to the codebase, please open a pull request on our GitHub repository. This allows us to review, discuss, and integrate contributions in a transparent and collaborative manner. Make sure to include a clear description of the changes and link any related issues if applicable. 
+If you make changes or improvements to the codebase, please open a pull request on our GitHub repository. This allows us to review, discuss, and integrate contributions in a transparent and collaborative manner. Make sure to include a clear description of the changes and link any related issues if applicable.
 
 Developer Setup
 ---------------
@@ -26,7 +26,7 @@ Developer Setup
     $ just dev
 
 3. Run code checks::
-    
+
     $ just check
 
 .. _`just`: https://github.com/casey/just
@@ -51,7 +51,7 @@ If you use ``dynsight`` please cite
 * If you use timeSOAP, please cite https://doi.org/10.1063/5.0147025
 * If you use LENS, please cite: https://doi.org/10.1073/pnas.2300565120
 * If you use onion-clustering, please cite: https://doi.org/10.1073/pnas.2403771121
-* If you use tICA, please cite ``deeptime`` https://deeptime-ml.github.io/latest/index.html 
+* If you use tICA, please cite ``deeptime`` https://deeptime-ml.github.io/latest/index.html
 * If you use ``dynsight.vision``, please cite Ultralytics YOLO https://docs.ultralytics.com/it/models/yolo11/#usage-examples
 * If you use ``dynsight.track``, please cite Trackpy https://soft-matter.github.io/trackpy/dev/introduction.html
 
@@ -69,4 +69,3 @@ The work was funded by the European Union and ERC under projects DYNAPOL and the
 NextGenerationEU project, CAGEX.
 
 .. figure:: docs/source/_static/EU_image.png
-

--- a/README.rst
+++ b/README.rst
@@ -53,9 +53,9 @@ How to contribute
 -----------------
 
 If you make changes or improvements to the codebase, please open a pull request
- on our GitHub repository. This allows us to review, discuss, and integrate
- contributions in a transparent and collaborative manner. Make sure to include
- a clear description of the changes and link any related issues if applicable.
+on our GitHub repository. This allows us to review, discuss, and integrate
+contributions in a transparent and collaborative manner. Make sure to include
+a clear description of the changes and link any related issues if applicable.
 
 
 Developer Setup

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@
 Overview
 ========
 
-:mod:`.dynsight` is structured to support a wide range of tasks commonly
+``dynsight`` is structured to support a wide range of tasks commonly
 encountered in the analysis of many-body dynamical systems. These tasks
 include handling trajectory data, computing single-particle descriptors,
 performing time-series clustering and conducting various auxiliary analyses.

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,20 @@
     `simonemartino <https://github.com/SimoneMartino98/>`_
 :documentation: https://dynsight.readthedocs.io
 
+Overview
+========
+
+:mod:`.dynsight` is structured to support a wide range of tasks commonly
+encountered in the analysis of many-body dynamical systems. These tasks
+include handling trajectory data, computing single-particle descriptors,
+performing time-series clustering and conducting various auxiliary analyses.
+To achieve this, dynsight is organized into specialized modules, each
+addressing a specific aspect of this workflow.
+
+Previously in `cpctools`_.
+
+.. _`cpctools`: https://github.com/GMPavanLab/cpctools
+
 Installation
 ============
 
@@ -11,21 +25,48 @@ To get ``dynsight``, you can install it with pip::
 
     $ pip install dynsight
 
+Optional Dependancies
+.....................
+
+Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if
+you are using Python 3.10 and below, you can use :mod:`cpctools` to access
+:mod:`SOAPify` and :mod:`hd5er` using ::
+
+  $ pip install cpctools
+
+If you want to use the :mod:`dynsight.tica` module you will need to install the
+ deeptime package. This can be done with with pip::
+
+  $ pip install deeptime
+
+or with conda::
+
+  $ conda install -c conda-forge deeptime
+
+If you want to use the :mod:`dynsight.vision` and :mod:`dynsight.track` modules
+you will need to install a series of packages. This can be done with with pip::
+
+  $ pip install ultralytics PyYAML
+
 
 How to contribute
-=================
+-----------------
 
-If you make changes or improvements to the codebase, please open a pull request on our GitHub repository. This allows us to review, discuss, and integrate contributions in a transparent and collaborative manner. Make sure to include a clear description of the changes and link any related issues if applicable.
+If you make changes or improvements to the codebase, please open a pull request
+ on our GitHub repository. This allows us to review, discuss, and integrate
+ contributions in a transparent and collaborative manner. Make sure to include
+ a clear description of the changes and link any related issues if applicable.
+
 
 Developer Setup
----------------
+...............
 
-1. Install `just`_.
-2. In a new virtual environment run using Python 3.10::
+#. Install `just`_.
+#. In a new virtual environment run::
 
     $ just dev
 
-3. Run code checks::
+#. Run code checks::
 
     $ just check
 
@@ -34,7 +75,8 @@ Developer Setup
 Examples
 ========
 
-There are examples available in the ``examples/`` directory of this repository.
+There are examples throughout the documentation and available in
+the ``examples/`` directory of this repository.
 
 There are also examples available in the ``cpctools`` repository
 `here <https://github.com/GMPavanLab/cpctools/tree/main/Examples>`
@@ -45,6 +87,10 @@ How To Cite
 If you use ``dynsight`` please cite
 
     https://github.com/GMPavanLab/dynsight
+
+and
+
+    TBD
 
 * Most modules also use MDAnalysis, https://www.mdanalysis.org/pages/citations/
 * If you use SOAP, please cite https://doi.org/10.1103/PhysRevB.87.184115 and DScribe https://singroup.github.io/dscribe/latest/citing.html

--- a/README.rst
+++ b/README.rst
@@ -28,13 +28,13 @@ To get ``dynsight``, you can install it with pip::
 Optional Dependancies
 .....................
 
-Old versions `dynsight` used :mod:`cpctools` for SOAP calculations, if
-you are using Python 3.10 and below, you can use :mod:`cpctools` to access
-:mod:`SOAPify` and :mod:`hd5er` using ::
+Old versions ``dynsight`` used ``cpctools`` for SOAP calculations, if
+you are using Python 3.10 and below, you can use ``cpctools`` to access
+``SOAPify`` and ``hd5er`` using ::
 
   $ pip install cpctools
 
-If you want to use the :mod:`dynsight.tica` module you will need to install the
+If you want to use the ``dynsight.tica`` module you will need to install the
 deeptime package. This can be done with with pip::
 
   $ pip install deeptime
@@ -43,7 +43,7 @@ or with conda::
 
   $ conda install -c conda-forge deeptime
 
-If you want to use the :mod:`dynsight.vision` and :mod:`dynsight.track` modules
+If you want to use the ``dynsight.vision`` and ``dynsight.track`` modules
 you will need to install a series of packages. This can be done with with pip::
 
   $ pip install ultralytics PyYAML

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ To get ``dynsight``, you can install it with pip::
     $ pip install dynsight
 
 Optional Dependancies
-.....................
+---------------------
 
 Old versions ``dynsight`` used ``cpctools`` for SOAP calculations, if
 you are using Python 3.10 and below, you can use ``cpctools`` to access
@@ -59,7 +59,7 @@ a clear description of the changes and link any related issues if applicable.
 
 
 Developer Setup
-...............
+---------------
 
 #. Install `just`_.
 #. In a new virtual environment run::

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ To get ``dynsight``, you can install it with pip::
 Optional Dependancies
 .....................
 
-Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if
+Old versions `dynsight` used :mod:`cpctools` for SOAP calculations, if
 you are using Python 3.10 and below, you can use :mod:`cpctools` to access
 :mod:`SOAPify` and :mod:`hd5er` using ::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -63,7 +63,7 @@ you are using Python 3.10 and below, you can use :mod:`cpctools` to access
   $ pip install cpctools
 
 If you want to use the :mod:`dynsight.tica` module you will need to install the
- deeptime package. This can be done with with pip::
+deeptime package. This can be done with with pip::
 
   $ pip install deeptime
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,9 +81,9 @@ How to contribute
 -----------------
 
 If you make changes or improvements to the codebase, please open a pull request
- on our GitHub repository. This allows us to review, discuss, and integrate
- contributions in a transparent and collaborative manner. Make sure to include
- a clear description of the changes and link any related issues if applicable.
+on our GitHub repository. This allows us to review, discuss, and integrate
+contributions in a transparent and collaborative manner. Make sure to include
+a clear description of the changes and link any related issues if applicable.
 
 
 Developer Setup

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. dynsight documentation master file, created by
-   sphinx-quickstart on Thu Oct 19 15:55:32 2023.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 .. toctree::
    :hidden:
    :caption: dynsight
@@ -33,13 +28,17 @@
 
   Modules <modules>
 
-Introduction
-------------
+Overview
+========
 
 | GitHub: https://www.github.com/GMPavanLab/dynsight
 
-
-:mod:`.dynsight` is a Python library aimed at simplifying the analysis of Molecular Dynamics simulations.
+:mod:`.dynsight` is structured to support a wide range of tasks commonly
+encountered in the analysis of many-body dynamical systems. These tasks
+include handling trajectory data, computing single-particle descriptors,
+performing time-series clustering and conducting various auxiliary analyses.
+To achieve this, dynsight is organized into specialized modules, each
+addressing a specific aspect of this workflow.
 
 Previously in `cpctools`_.
 
@@ -47,27 +46,24 @@ Previously in `cpctools`_.
 
 
 Installation
-------------
+============
 
 To get :mod:`.dynsight`, you can install it with pip::
 
   $ pip install dynsight
 
-Dependencies
-............
-
-The main dependency is for SOAP analysis:
-
-* `dscribe (1.2.0 - 1.2.2) <https://singroup.github.io/dscribe/latest/>`_
 
 Optional Dependancies
 .....................
 
-Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if you are using Python 3.10 and below, you can use :mod:`cpctools` to access :mod:`SOAPify` and :mod:`hd5er` using ::
+Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if
+you are using Python 3.10 and below, you can use :mod:`cpctools` to access
+:mod:`SOAPify` and :mod:`hd5er` using ::
 
   $ pip install cpctools
 
-If you want to use the :mod:`dynsight.tica` module you will need to install the deeptime package. This can be done with with pip::
+If you want to use the :mod:`dynsight.tica` module you will need to install the
+ deeptime package. This can be done with with pip::
 
   $ pip install deeptime
 
@@ -75,11 +71,20 @@ or with conda::
 
   $ conda install -c conda-forge deeptime
 
+If you want to use the :mod:`dynsight.vision` and :mod:`dynsight.track` modules
+you will need to install a series of packages. This can be done with with pip::
+
+  $ pip install ultralytics PyYAML
+
 
 How to contribute
 -----------------
 
-If you make changes or improvements to the codebase, please open a pull request on our GitHub repository. This allows us to review, discuss, and integrate contributions in a transparent and collaborative manner. Make sure to include a clear description of the changes and link any related issues if applicable. 
+If you make changes or improvements to the codebase, please open a pull request
+ on our GitHub repository. This allows us to review, discuss, and integrate
+ contributions in a transparent and collaborative manner. Make sure to include
+ a clear description of the changes and link any related issues if applicable.
+
 
 Developer Setup
 ...............
@@ -98,41 +103,39 @@ Developer Setup
 .. _`just`: https://github.com/casey/just
 
 
-Overview
---------
-
-``dynsight`` is structured to support a wide range of tasks commonly encountered in the analysis of many-body dynamical systems. These tasks include handling trajectory data, computing single-particle descriptors, performing time-series clustering and conducting various auxiliary analyses. To achieve this, dynsight is organized into specialized modules, each addressing a specific aspect of this workflow. 
-
 Examples
---------
+========
 
-There are simplified examples available in the
-`examples <https://github.com/GMPavanLab/dynsight/tree/main/examples>`_
-directory of this repository.
+There are examples throughout the documentation and available in
+the ``examples/`` directory of this repository.
 
 There are also examples available in the ``cpctools`` repository
-`here <https://github.com/GMPavanLab/cpctools/tree/main/Examples>`_.
+`here <https://github.com/GMPavanLab/cpctools/tree/main/Examples>`
 
 
 How To Cite
------------
+===========
 
 If you use ``dynsight`` please cite
 
     https://github.com/GMPavanLab/dynsight
+
+and
+
+    TBD
 
 * Most modules also use MDAnalysis, https://www.mdanalysis.org/pages/citations/
 * If you use SOAP, please cite https://doi.org/10.1103/PhysRevB.87.184115 and DScribe https://singroup.github.io/dscribe/latest/citing.html
 * If you use timeSOAP, please cite https://doi.org/10.1063/5.0147025
 * If you use LENS, please cite: https://doi.org/10.1073/pnas.2300565120
 * If you use onion-clustering, please cite: https://doi.org/10.1073/pnas.2403771121
-* If you use tICA, please cite ``deeptime`` https://deeptime-ml.github.io/latest/index.html 
+* If you use tICA, please cite ``deeptime`` https://deeptime-ml.github.io/latest/index.html
 * If you use ``dynsight.vision``, please cite Ultralytics YOLO https://docs.ultralytics.com/it/models/yolo11/#usage-examples
 * If you use ``dynsight.track``, please cite Trackpy https://soft-matter.github.io/trackpy/dev/introduction.html
 
 
 Acknowledgements
-----------------
+================
 
 We developed this code when working in the Pavan group,
 https://www.gmpavanlab.polito.it/, whose members often provide very valuable

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -54,7 +54,7 @@ To get :mod:`.dynsight`, you can install it with pip::
 
 
 Optional Dependancies
-.....................
+---------------------
 
 Old versions :mod:`dynsight` used :mod:`cpctools` for SOAP calculations, if
 you are using Python 3.10 and below, you can use :mod:`cpctools` to access
@@ -87,7 +87,7 @@ a clear description of the changes and link any related issues if applicable.
 
 
 Developer Setup
-...............
+---------------
 
 #. Install `just`_.
 #. In a new virtual environment run::

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 
 # Build docs.
 docs:
-  rm -rf docs/source/_autosummary
+  rm -rf docs/build docs/source/_autosummary
   make -C docs html
   echo Docs are in $PWD/docs/build/html/index.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,13 @@ dependencies = [
     "dscribe",
     "tropea-clustering",
     "MDAnalysis",
-    "ultralytics",
-    "PyYAML",
+    "kaleido==0.2.0",
 ]
 # Set by cpctools.
 requires-python = ">=3.8"
 dynamic = ["version"]
 readme = "README.rst"
-description = "Simplifies analysis of Molecular Dynamics simulations."
+description = "Simplifies analysis of simulation and experimental trajectories."
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,7 @@ maintainers = [
     { name = "Simone Martino", email = "s.martino0898@gmail.com" },
 ]
 
-dependencies = [
-    "numpy",
-    "dscribe",
-    "tropea-clustering",
-    "MDAnalysis",
-    "kaleido==0.2.0",
-]
+dependencies = ["numpy", "dscribe", "tropea-clustering", "MDAnalysis"]
 # Set by cpctools.
 requires-python = ">=3.8"
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,5 +110,6 @@ module = [
     'Pillow.*',
     'ultralytics.*',
     'opencv-python.*',
+    'cv2.*',
 ]
 ignore_missing_imports = true

--- a/src/dynsight/_internal/vision/detect.py
+++ b/src/dynsight/_internal/vision/detect.py
@@ -8,13 +8,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 
 import numpy as np
-import yaml
 from PIL import Image
 
 try:
     from ultralytics import YOLO
 except ImportError:
     YOLO = None
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
 
 from .vision_gui import VisionGUI
 from .vision_utilities import find_outliers

--- a/src/dynsight/_internal/vision/detect.py
+++ b/src/dynsight/_internal/vision/detect.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict, cast
 import numpy as np
 import yaml
 from PIL import Image
-from ultralytics import YOLO
+
+try:
+    from ultralytics import YOLO
+except ImportError:
+    YOLO = None
 
 from .vision_gui import VisionGUI
 from .vision_utilities import find_outliers

--- a/src/dynsight/_internal/vision/video_to_frame.py
+++ b/src/dynsight/_internal/vision/video_to_frame.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-import cv2
+try:
+    import cv2
+except ImportError:
+    cv2 = None
 
 if TYPE_CHECKING:
     import pathlib

--- a/src/dynsight/_internal/vision/video_to_frame.py
+++ b/src/dynsight/_internal/vision/video_to_frame.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 try:
     import cv2
 except ImportError:
-    cv2 = None
+    cv2 = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     import pathlib


### PR DESCRIPTION
Related Issues: #94 

I initially opened this (over #95) to use `uv` in the tooling, but this was not trivial at this time, so I gave up.

Difficulties came from:

- `tropea-clustering` and `kaleido`
- `dscribe`
- our wide python version allowance
