### PR TITLE
Making ``compute_aver_align()`` more general and public 

### DIFF
--- a/src/dynsight/_internal/descriptors/misc.py
+++ b/src/dynsight/_internal/descriptors/misc.py
@@ -95,7 +95,7 @@ def orientational_order_param(
     return psi
 
 
-def compute_aver_align(
+def compute_mean_alignment(
     neigh_list_t: list[AtomGroup],
     vectors: NDArray[np.float64],  # shape (n_atoms, n_dim)
     metric: Callable[[NDArray[np.float64], NDArray[np.float64]], float],
@@ -195,7 +195,7 @@ def velocity_alignment(
     ):  # If the Universe has velocities, use them
         phi = np.zeros((n_frames, n_atoms))
         for t, _ in enumerate(universe.trajectory):
-            phi[t] = compute_aver_align(
+            phi[t] = compute_mean_alignment(
                 neigh_list_per_frame[t],
                 vectors=universe.atoms.velocities,
                 metric=cosine_distance,
@@ -211,7 +211,7 @@ def velocity_alignment(
             r_0 = r_1
             continue
         frame_vel = r_1 - r_0
-        phi[t - 1] = compute_aver_align(
+        phi[t - 1] = compute_mean_alignment(
             neigh_list_per_frame[t - 1],
             vectors=frame_vel,
             metric=cosine_distance,

--- a/src/dynsight/descriptors.py
+++ b/src/dynsight/descriptors.py
@@ -1,7 +1,7 @@
 """descriptors package."""
 
 from dynsight._internal.descriptors.misc import (
-    compute_aver_align,
+    compute_mean_alignment,
     orientational_order_param,
     velocity_alignment,
 )
@@ -10,7 +10,7 @@ from dynsight._internal.descriptors.tica import (
 )
 
 __all__ = [
-    "compute_aver_align",
+    "compute_mean_alignment",
     "many_body_tica",
     "orientational_order_param",
     "velocity_alignment",


### PR DESCRIPTION
Requested Reviewers: @andrewtarzia @SimoneMartino98 

I modified the function compute_aver_align() so that now it can be clearly used to compute the average alignment of any local vector field associated to the particles. 

I made the metric used to quantify alignment a parameter. 

I made the function public so that the users can use it. 